### PR TITLE
Changed version numbers from int to long

### DIFF
--- a/src/Nomad.Framework/MigrationAttribute.cs
+++ b/src/Nomad.Framework/MigrationAttribute.cs
@@ -4,14 +4,14 @@ namespace Nomad.Framework
 {
     public class MigrationAttribute : Attribute
     {
-        private readonly int version;
+        private readonly long version;
 
-        public MigrationAttribute(int version)
+        public MigrationAttribute(long version)
         {
             this.version = version;
         }
 
-        public int Version
+        public long Version
         {
             get { return version; }
         }

--- a/src/Nomad/Migrations/ChangeSet.cs
+++ b/src/Nomad/Migrations/ChangeSet.cs
@@ -4,7 +4,7 @@ namespace Nomad.Migrations
 {
     public class ChangeSet
     {
-        public int Version { get; set; }
+        public long Version { get; set; }
         public Migration Change { get; set; }
     }
 }

--- a/src/Nomad/Migrations/ISchema.cs
+++ b/src/Nomad/Migrations/ISchema.cs
@@ -7,7 +7,7 @@ namespace Nomad.Migrations
         IDatabase Database { get; }
         bool SchemaTableCountIsZero { get; }
         int GetLatestSchemaVersion();
-        void UpdateSchemaVersionTo(int version);
+        void UpdateSchemaVersionTo(long version);
         void EnsureSchemaVersionTable();
         void CreateSchemaVersionTable();
     }

--- a/src/Nomad/Migrations/Schema.cs
+++ b/src/Nomad/Migrations/Schema.cs
@@ -40,7 +40,7 @@ namespace Nomad.Migrations
             return !string.IsNullOrEmpty(string.Concat(string.Empty, result));
         }
 
-        public void UpdateSchemaVersionTo(int version)
+        public void UpdateSchemaVersionTo(long version)
         {
             var sqlToExecute = string.Format(Resources.InsertSchemaVersion, version);
             Database.ExecuteNonQuery(sqlToExecute);

--- a/src/Nomad/Migrations/TypeExtensions.cs
+++ b/src/Nomad/Migrations/TypeExtensions.cs
@@ -19,7 +19,7 @@ namespace Nomad.Migrations
                 .ToList();
         }
 
-        private static int GetVersion(Type x)
+        private static long GetVersion(Type x)
         {
             var attribute = x.GetCustomAttributes(typeof(MigrationAttribute), true)
                                 .FirstOrDefault() as MigrationAttribute;


### PR DESCRIPTION
The SchemaInfo table accommodates bigint but the code side of things only accommodates a 32-bit integer. Changed the code so it uses a 64-bit integer, same as the DB.